### PR TITLE
nox_main.cc: unused variable warning corrected.

### DIFF
--- a/src/nox_main.cc
+++ b/src/nox_main.cc
@@ -160,10 +160,10 @@ void usage(const char* program_name)
            "  -i pssl:[IP]:[PORT]:KEY:CERT:CONTROLLER_CA_CERT\n"
            "                          listen to SSL PORT on interface specified by IP\n"
            "                          (default: 0.0.0.0:%d)\n"
-#ifdef RELIABLE_ENABLED
+#ifdef UNRELIABLE_ENABLED
            "\nNetwork control options (must also specify an interface):\n"
            "  -u, --unreliable        do not reconnect to interfaces on error\n"
-#endif // RELIABLE_ENABLED
+#endif // UNRELIABLE_ENABLED
            , program_name, program_name, 6633, 6633);
     //program_name, program_name, OFP_TCP_PORT, OFP_SSL_PORT);
     printf("\nOther options:\n"
@@ -291,9 +291,9 @@ int main(int argc, char *argv[])
     const char* pid_file = "/var/run/nox.pid";
     const char* info_file = "./nox.info";
     unsigned int n_threads = 1;
-#ifdef RELIABLE_ENABLED
+#ifdef UNRELIABLE_ENABLED
     bool reliable = true;
-#endif // RELIABLE_ENABLED
+#endif // UNRELIABLE_ENABLED
     bool daemon_flag = false;
     list<string> interfaces;
 
@@ -316,9 +316,9 @@ int main(int argc, char *argv[])
         static struct option long_options[] =
         {
             {"daemon",      no_argument, 0, 'd'},
-#ifdef RELIABLE_ENABLED
+#ifdef UNRELIABLE_ENABLED
             {"unreliable",  no_argument, 0, 'u'},
-#endif // RELIABLE_ENABLED
+#endif // UNRELIABLE_ENABLED
 
             {"interface",   required_argument, 0, 'i'},
 
@@ -352,11 +352,11 @@ int main(int argc, char *argv[])
             daemon_flag = true;
             break;
 
-#ifdef RELIABLE_ENABLED
+#ifdef UNRELIABLE_ENABLED
         case 'u':
             reliable = false;
             break;
-#endif // RELIABLE_ENABLED
+#endif // UNRELIABLE_ENABLED
 
         case 'i':
             interfaces.push_back(optarg);

--- a/src/nox_main.cc
+++ b/src/nox_main.cc
@@ -160,9 +160,11 @@ void usage(const char* program_name)
            "  -i pssl:[IP]:[PORT]:KEY:CERT:CONTROLLER_CA_CERT\n"
            "                          listen to SSL PORT on interface specified by IP\n"
            "                          (default: 0.0.0.0:%d)\n"
+#ifdef RELIABLE_ENABLED
            "\nNetwork control options (must also specify an interface):\n"
-           "  -u, --unreliable        do not reconnect to interfaces on error\n",
-           program_name, program_name, 6633, 6633);
+           "  -u, --unreliable        do not reconnect to interfaces on error\n"
+#endif // RELIABLE_ENABLED
+           , program_name, program_name, 6633, 6633);
     //program_name, program_name, OFP_TCP_PORT, OFP_SSL_PORT);
     printf("\nOther options:\n"
            "  -c, --conf=FILE         set configuration file\n"
@@ -289,7 +291,9 @@ int main(int argc, char *argv[])
     const char* pid_file = "/var/run/nox.pid";
     const char* info_file = "./nox.info";
     unsigned int n_threads = 1;
+#ifdef RELIABLE_ENABLED
     bool reliable = true;
+#endif // RELIABLE_ENABLED
     bool daemon_flag = false;
     list<string> interfaces;
 
@@ -312,7 +316,9 @@ int main(int argc, char *argv[])
         static struct option long_options[] =
         {
             {"daemon",      no_argument, 0, 'd'},
+#ifdef RELIABLE_ENABLED
             {"unreliable",  no_argument, 0, 'u'},
+#endif // RELIABLE_ENABLED
 
             {"interface",   required_argument, 0, 'i'},
 
@@ -346,9 +352,11 @@ int main(int argc, char *argv[])
             daemon_flag = true;
             break;
 
+#ifdef RELIABLE_ENABLED
         case 'u':
             reliable = false;
             break;
+#endif // RELIABLE_ENABLED
 
         case 'i':
             interfaces.push_back(optarg);


### PR DESCRIPTION
Issue #15

Correcting compilation warning by wrapping reliable functionality under RELIABLE_ENABLED macro.

../../src/nox_main.cc: In function ‘int main(int, char**)’:
../../src/nox_main.cc:293:10: warning: variable ‘reliable’ set but not used [-Wunused-but-set-variable]
