### PR TITLE
connection-manager: cleanup of hardcoded connection types.

### DIFF
--- a/src/builtin/connection-manager.cc
+++ b/src/builtin/connection-manager.cc
@@ -49,7 +49,14 @@ namespace bassl = ::boost::asio::ssl;
 
 static Vlog_module lg("connection_manager");
 
-static const std::string conn_t_str[] = { "tcp", "ssl", "ptcp", "pssl" };
+const std::string Connection_manager::Connection_type_string[_AMMOUNT] =
+{
+    "tcp",
+    "ssl",
+    "ptcp",
+    "pssl",
+    "unknown"
+};
 
 Connection_manager::Connection_manager(const Component_context* ctxt,
                                        const std::list<std::string>& interfaces)
@@ -85,7 +92,7 @@ Connection_manager::install()
     /* Bind/listen to interfaces */
     BOOST_FOREACH(const std::string& interface, interfaces)
     {
-        Conn_t type;
+        Connection_type type;
         std::string host, key, cert, cafile;
         uint16_t port;
 
@@ -112,21 +119,21 @@ Connection_manager::install()
         if (type == TCP || type == SSL)
         {
             VLOG_DBG(lg, "connecting to %s:%s:%d:%s:%s:%s",
-                     conn_t_str[type].c_str(), host.c_str(), port,
+                     Connection_type_string[type].c_str(), host.c_str(), port,
                      key.c_str(), cert.c_str(), cafile.c_str());
             connect(type, host, port, key, cert, cafile);
         }
         else if (type == PTCP || type == PSSL)
         {
             VLOG_DBG(lg, "listening on %s:%s:%d:%s:%s:%s",
-                     conn_t_str[type].c_str(), host.c_str(), port,
+                     Connection_type_string[type].c_str(), host.c_str(), port,
                      key.c_str(), cert.c_str(), cafile.c_str());
             listen(type, host, port, key, cert, cafile);
         }
         else
         {
             throw std::runtime_error("Unsupported connection type \""
-                                     + conn_t_str[type] + "\"");
+                                     + Connection_type_string[type] + "\"");
         }
     }
 
@@ -137,7 +144,7 @@ Connection_manager::install()
 
 void
 Connection_manager::parse(const std::string& interface,
-                          Conn_t& type,
+                          Connection_type& type,
                           std::string& host,
                           uint16_t& port,
                           std::string& key,
@@ -159,13 +166,13 @@ Connection_manager::parse(const std::string& interface,
     size_t ntokens = tokens.size();
     if (ntokens >= 1)
     {
-        if (tokens[0] == "tcp")
+        if (tokens[0] == Connection_type_string[TCP])
             type = TCP;
-        else if (tokens[0] == "ssl")
+        else if (tokens[0] == Connection_type_string[SSL])
             type = SSL;
-        else if (tokens[0] == "ptcp")
+        else if (tokens[0] == Connection_type_string[PTCP])
             type = PTCP;
-        else if (tokens[0] == "pssl")
+        else if (tokens[0] == Connection_type_string[PSSL])
             type = PSSL;
 
         if (ntokens == 2)
@@ -245,7 +252,7 @@ Connection_manager::handle_handshake(bassl::stream_base::handshake_type type,
 }
 
 void
-Connection_manager::connect(Conn_t type,
+Connection_manager::connect(Connection_type type,
                             const std::string& host, const uint16_t& port,
                             const std::string& key,
                             const std::string& cert,
@@ -329,7 +336,7 @@ Connection_manager::listen(boost::shared_ptr<boost::asio::ip::tcp::acceptor> acc
 }
 
 void
-Connection_manager::listen(Conn_t type,
+Connection_manager::listen(Connection_type type,
                            const std::string& bind_ip, const uint16_t& port,
                            const std::string& key,
                            const std::string& cert,

--- a/src/builtin/connection-manager.cc
+++ b/src/builtin/connection-manager.cc
@@ -49,7 +49,7 @@ namespace bassl = ::boost::asio::ssl;
 
 static Vlog_module lg("connection_manager");
 
-const std::string Connection_manager::Connection_type_string[_AMMOUNT] =
+const std::string Connection_manager::Connection_type_string[NR_CONNECTION_TYPES] =
 {
     "tcp",
     "ssl",

--- a/src/include/connection-manager.hh
+++ b/src/include/connection-manager.hh
@@ -64,10 +64,10 @@ private:
         PSSL = 3,
         UNKNOWN = 4,
         // should be last
-        _AMMOUNT = UNKNOWN+1
+        NR_CONNECTION_TYPES = UNKNOWN+1
     };
 
-    static const std::string Connection_type_string[_AMMOUNT];
+    static const std::string Connection_type_string[NR_CONNECTION_TYPES];
 
     typedef boost::function<void()> Listen_callback;
     //typedef std::string Protocol_name;

--- a/src/include/connection-manager.hh
+++ b/src/include/connection-manager.hh
@@ -55,7 +55,19 @@ public:
     void install();
 
 private:
-    enum Conn_t { TCP, SSL, PTCP, PSSL, UNKNOWN };
+
+    enum Connection_type
+    {
+        TCP = 0,
+        SSL = 1,
+        PTCP = 2,
+        PSSL = 3,
+        UNKNOWN = 4,
+        // should be last
+        _AMMOUNT = UNKNOWN+1
+    };
+
+    static const std::string Connection_type_string[_AMMOUNT];
 
     typedef boost::function<void()> Listen_callback;
     //typedef std::string Protocol_name;
@@ -72,7 +84,7 @@ private:
                        const std::list<std::string>& interfaces);
 
     void parse(const std::string& interface,
-               Conn_t& type,
+               Connection_type& type,
                std::string& ip,
                uint16_t& port,
                std::string& key,
@@ -88,7 +100,7 @@ private:
                           boost::shared_ptr<ssl_socket>,
                           Listen_callback, const boost::system::error_code&);
 
-    void connect(Conn_t type, const std::string& host, const uint16_t& port,
+    void connect(Connection_type type, const std::string& host, const uint16_t& port,
                  const std::string& key,
                  const std::string& cert,
                  const std::string& cafile);
@@ -98,7 +110,7 @@ private:
                 const std::string& key,
                 const std::string& cert,
                 const std::string& cafile);
-    void listen(Conn_t type, const std::string& bind_ip, const uint16_t& port,
+    void listen(Connection_type type, const std::string& bind_ip, const uint16_t& port,
                 const std::string& key,
                 const std::string& cert,
                 const std::string& cafile);


### PR DESCRIPTION
Connection types and their names should be in sync and not hardcoded thru the code.
On the way added better naming to connection type variables.
