### PR TITLE
fix the parameter passing to app

### DIFF
--- a/src/builtin/component.cc
+++ b/src/builtin/component.cc
@@ -136,9 +136,9 @@ Component_context::Component_context(const Component_name& name,
                 BOOST_FOREACH(const std::string& str, args)
                 {
                     std::string key("args.");
-                    // use comma as the separator
+                    // use equal sign as the separator
                     std::vector<std::string> kv;
-                    boost::split(kv, str, boost::is_any_of(","));
+                    boost::split(kv, str, boost::is_any_of("="));
                     key += kv[0];
                     properties.put(key, kv.size() > 1 ? kv[1] : "");
                 }


### PR DESCRIPTION
Suppose we use this kind of format to pass our parameter, just as what the comment show us .
// parse it as key=value
./nox_core -v -i ptcp:6633 discovery=a=1,b=2

We should replace the second ',' with '=', so that the value can be stored correctly.
