### PR TITLE
fix Openflow_datapath_leave_event

### DIFF
--- a/src/coreapps/openflow/openflow-datapath.cc
+++ b/src/coreapps/openflow/openflow-datapath.cc
@@ -128,6 +128,8 @@ Openflow_datapath::close() const
 void
 Openflow_datapath::close_cb()
 {
+    Openflow_datapath_leave_event dple(shared_from_this());
+    manager.dispatch(dple);
 }
 
 void


### PR DESCRIPTION
dispatch Openflow_datapath_leave_event, so that we can use it in the other app.
